### PR TITLE
Fixed Elements getting out of border in Job Filter

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -95,7 +95,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
                         });
                     }}
                 >
-                    <SelectTrigger className="w-[180px]">
+                    <SelectTrigger className="w-[160px] p-2">
                         <SelectValue placeholder="Choose currency" />
                     </SelectTrigger>
                     <SelectContent>
@@ -112,7 +112,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
                         });
                     }}
                 >
-                    <SelectTrigger className="w-[180px]">
+                    <SelectTrigger className="w-[160px]">
                         <SelectValue placeholder="Job Location" />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
Fixes #90 

This pr fixes two elements ( choose currency and job location select triggers) which are getting out of border.

Here I have fixed the width of element to 160px as  width of sidebar  does not changes on all sizes of screen.

This size of the element works in all the sizes of screen and does not get out of the border.

![image](https://github.com/user-attachments/assets/f6253ea9-78d1-4540-be9b-23f7b5c271cf)

![image](https://github.com/user-attachments/assets/4009444a-d281-4c8e-9ad1-80df3a7c7c4b)

