### PR TITLE
Fixes: widths of Sidebar Elements  and Navbar increased.

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -62,7 +62,7 @@ const Navbar = ({ session }: NavbarProps) => {
   const userRole = session?.user.role;
 
   return (
-    <nav className="w-3/6 flex items-center justify-between h-14 border-t shadow border-gray-150 rounded-lg px-3 transition-all backdrop-blur-lg bg-background/50">
+    <nav className="w-2/3 flex items-center justify-between h-14 border-t shadow border-gray-150 rounded-lg px-3 transition-all backdrop-blur-lg bg-background/50">
       <div className="flex justify-center items-center gap-10">
         <h3 className="text-xl bg-gradient-to-r from-indigo-600 via-violet-500 to-blue-700 bg-clip-text text-transparent font-black">
           100xJobs

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -95,7 +95,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
                         });
                     }}
                 >
-                    <SelectTrigger className="w-[180px]">
+                    <SelectTrigger className="w-full">
                         <SelectValue placeholder="Choose currency" />
                     </SelectTrigger>
                     <SelectContent>
@@ -112,7 +112,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
                         });
                     }}
                 >
-                    <SelectTrigger className="w-[180px]">
+                    <SelectTrigger className="w-full">
                         <SelectValue placeholder="Job Location" />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
Fixes #90 

Before : Navbar content is overflowed before the sm breakpoint (only occurs for the Admin Login).
![image](https://github.com/user-attachments/assets/1cab601c-33bd-40e2-894c-250bb17dd748)

After: Increased the width of the Navbar by 16%.
![image](https://github.com/user-attachments/assets/1bfd48e2-9798-4928-9ada-a3265929d5fa)

SideBar:
Before:Input Elements Overflowing in small view widths and and not Aligned with the above Input fields
![image](https://github.com/user-attachments/assets/61e2efb5-aea9-45d0-9ef2-c3cf06407b48)

After:Fixes the width to full and it aligns with the Above two input fields.
![image](https://github.com/user-attachments/assets/fe7acc2f-918b-4c89-ac3b-260a18a05232)



