### PR TITLE
Fix too many requests by debouncing filters and make its custom hook

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Job } from "@prisma/client";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface SidebarProps {
   setJobs: (jobs: Job[]) => void;
@@ -45,6 +46,8 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
     salRange: [0, 1000000],
   });
 
+  const debouncedFilters = useDebounce<Filters>(filters);
+
   const handleFilterChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFilters({
       ...filters,
@@ -62,7 +65,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
   const fetchJobs = async () => {
     setLoading(true);
     //@ts-ignore
-    const response = await getJobs(filters);
+    const response = await getJobs(debouncedFilters);
     if (response.status === "success") {
       //@ts-ignore
       setJobs(response.data);
@@ -72,7 +75,7 @@ const Sidebar = ({ setJobs, setLoading }: SidebarProps) => {
 
   useEffect(() => {
     fetchJobs();
-  }, [filters]);
+  }, [debouncedFilters]);
 
   return (
     <aside className="p-4 min-w-48 border border-gray-200 rounded">

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+
+export const useDebounce = <T>(input: T, delay: number = 500) => {
+    const [debouncedValue, setDebouncedValue] = useState(input);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedValue(input)
+        }, delay ?? 500);
+
+        return () => {
+            clearTimeout(timer);
+        }
+    }, [input, delay]);
+
+    return debouncedValue;
+}


### PR DESCRIPTION
## Fix #126 

Now, the frontend waits for 500 ms (can be changed easily) before calling `getJobs`. This way the server won't be flooded.

### Demo fix:-

https://github.com/user-attachments/assets/40f42dce-5772-4c52-bb42-4744f2dd3865

