### PR TITLE
fix: removed the fetch jobs function

### DIFF
--- a/app/(protected)/jobs/page.tsx
+++ b/app/(protected)/jobs/page.tsx
@@ -1,30 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import JobCard from "@/components/JobCard";
 import Sidebar from "@/components/Sidebar";
 import { cn } from "@/lib/utils";
-import { getJobs } from "@/actions/job";
 import { Job } from "@prisma/client";
 
 const JobsPage = () => {
   const [jobs, setJobs] = useState<Job[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    const fetchJobs = async () => {
-      setLoading(true);
-      //@ts-ignore
-      const response = await getJobs({});
-      if (response.status === "success") {
-        //@ts-ignore
-        setJobs(response.data);
-      }
-      setLoading(false);
-    };
-
-    fetchJobs();
-  }, []);
+  const [loading, setLoading] = useState(true);
 
   return (
     <section className="relative w-full h-fit flex gap-2 flex-grow">
@@ -44,7 +28,7 @@ const JobsPage = () => {
             {
               "h-[420px] flex justify-center items-center":
                 jobs.length === 0 && !loading,
-            },
+            }
           )}
         >
           {loading ? (


### PR DESCRIPTION
Removed the fetch jobs function from the main jobs page as it was not usable and only caused confusion. The sidebar component already handles the major part of fetching and setting up the jobs, resulting in two fetch functions running simultaneously. This not only adds an extra query to the database but also creates unnecessary confusion.


This thing is also handling the same code.
```
  <Sidebar setJobs={setJobs} setLoading={setLoading} />
```