### PR TITLE
[Fix] : Multiple API  calls in side bar and remove unnecessary api calls in jobs page

### DIFF
--- a/app/(protected)/jobs/page.tsx
+++ b/app/(protected)/jobs/page.tsx
@@ -1,34 +1,48 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import JobCard from "@/components/JobCard";
 import Sidebar from "@/components/Sidebar";
-import { cn } from "@/lib/utils";
+import { cn, debounce } from "@/lib/utils";
 import { getJobs } from "@/actions/job";
 import { Job } from "@prisma/client";
+import { DEFAULT_SALARY_RANGE } from "@/constants/constants";
+
+export interface Filters {
+  title: string;
+  companyName: string;
+  location: string;
+  currency: string;
+  salRange: [number, number];
+}
 
 const JobsPage = () => {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [loading, setLoading] = useState(false);
+  const [filters, setFilters] = useState<Filters>({
+    title: "",
+    companyName: "",
+    location: "",
+    currency: "",
+    salRange: [...DEFAULT_SALARY_RANGE],
+  });
 
   useEffect(() => {
-    const fetchJobs = async () => {
-      setLoading(true);
-      //@ts-ignore
-      const response = await getJobs({});
-      if (response.status === "success") {
-        //@ts-ignore
-        setJobs(response.data);
-      }
-      setLoading(false);
-    };
+    fetchJobs(filters);
+  }, [filters])
 
-    fetchJobs();
-  }, []);
+  const fetchJobs = async (filters: Filters) => {
+    setLoading(true);
+    const response = await getJobs(filters);
+    if (response && response?.status === "success") {
+      setJobs(response.data);
+    }
+    setLoading(false);
+  }
 
   return (
     <section className="relative w-full h-fit flex gap-2 flex-grow">
-      <Sidebar setJobs={setJobs} setLoading={setLoading} />
+      <Sidebar setFilters={setFilters} filters={filters} />
       <section className="w-full h-fit flex flex-col gap-8 rounded-md py-4 px-6">
         <div className="flex flex-col gap-1">
           <h3 className="lg:text-5xl text-gray-900 tracking-tight font-semibold">

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SALARY_RANGE: [number, number] = [0, 1000000];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Creates a debounced version of the provided function that delays its execution 
+ * until after a specified wait time has elapsed since the last time it was invoked.
+ *
+ * @template T - The type of the function to debounce.
+ * @param {T} func - The function to debounce.
+ * @param {number} [timeout=300] - The number of milliseconds to delay execution.
+ * @returns {(...args: Parameters<T>) => void} A debounced version of the provided function.
+ */
+export function debounce <T extends (...args: any[]) => any>(func: T, timeout = 300){
+  let timer: ReturnType<typeof setTimeout>;
+  return (...args: any[]) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func.apply(this, args); }, timeout);
+  };
+}


### PR DESCRIPTION
This PR fixes:

- Multiple API  calls in sidebar component whenever filters change.
- Adds a debouce util function which can be reused.
- Moved the filters state and api call in parent component (Jobs page).
- Removed unnecessary fetch jobs call in the Jobs page which was causing 2 extra API calls with empty payload on initial page load.

Fixes: #126 #146 

Before
[Before.webm](https://github.com/user-attachments/assets/e5c5a2af-2009-454d-899a-13abe8df3b60)

After
[After.webm](https://github.com/user-attachments/assets/984b6d5e-41e4-4e5b-a2c6-074368bff823)

