### PR TITLE
feat: Add password visibility toggle feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-scroll-area": "^1.1.0",

--- a/src/components/auth/signin.tsx
+++ b/src/components/auth/signin.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import APP_PATHS from '@/config/path.config';
@@ -20,10 +21,13 @@ import {
   FormMessage,
 } from '../ui/form';
 import { useToast } from '../ui/use-toast';
+import { EyeOpenIcon, EyeNoneIcon } from '@radix-ui/react-icons';
 
 const Signin = () => {
   const { toast } = useToast();
   const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+
   const form = useForm<SigninSchemaType>({
     resolver: zodResolver(SigninSchema),
     defaultValues: {
@@ -84,7 +88,24 @@ const Signin = () => {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" {...field} placeholder="••••••••" />
+                  <div className="relative">
+                    <Input
+                      type={showPassword ? 'text' : 'password'}
+                      {...field}
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((prev: boolean) => !prev)}
+                      className="absolute inset-y-0 right-0 flex items-center pr-4"
+                    >
+                      {showPassword ? (
+                        <EyeNoneIcon className="h-4 w-4" />
+                      ) : (
+                        <EyeOpenIcon className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/components/auth/signup.tsx
+++ b/src/components/auth/signup.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import APP_PATHS from '@/config/path.config';
@@ -20,11 +21,14 @@ import {
   FormMessage,
 } from '../ui/form';
 import { useToast } from '../ui/use-toast';
+import { EyeOpenIcon, EyeNoneIcon } from '@radix-ui/react-icons';
 
 const Signup = () => {
   // const searchParams = useSearchParams();
   const { toast } = useToast();
   const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+
   const form = useForm<SignupSchemaType>({
     resolver: zodResolver(SignupSchema),
     defaultValues: {
@@ -98,7 +102,24 @@ const Signup = () => {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" {...field} placeholder="••••••••" />
+                  <div className="relative">
+                    <Input
+                      type={showPassword ? 'text' : 'password'}
+                      {...field}
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((prev: boolean) => !prev)}
+                      className="absolute inset-y-0 right-0 flex items-center pr-4"
+                    >
+                      {showPassword ? (
+                        <EyeNoneIcon className="h-4 w-4" />
+                      ) : (
+                        <EyeOpenIcon className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
                 </FormControl>
                 <FormMessage />
               </FormItem>


### PR DESCRIPTION
 ## Description
This pull request implements a password visibility toggle feature in the signup and signin form, addressing issue #245. The enhancement allows users to toggle between showing and hiding their password, improving the overall user experience.

## Changes Made
- Implemented a toggle button with eye icons to switch between 'text' and 'password' input types.
- Ensured the implementation integrates seamlessly with the existing form structure and UI.

## Issue
- Resolves #245 

## Before

https://github.com/user-attachments/assets/e94cce5b-dd43-42c5-a97d-8e15bfb1db82

## After

https://github.com/user-attachments/assets/f727d76a-7123-4655-8dfb-57c2f3ef9ef8

## Testing
- The feature was tested locally, and the password visibility toggle is working as expected across different scenarios.
