### PR TITLE
fixed the typo in signin and signup page

### DIFF
--- a/src/components/auth/signin.tsx
+++ b/src/components/auth/signin.tsx
@@ -84,7 +84,7 @@ const Signin = () => {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" {...field} placeholder="••••••••" />
+                  <Input type="password" {...field} placeholder="Password" />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -95,7 +95,7 @@ const Signin = () => {
               href={APP_PATHS.RESET_PASSWORD}
               className="text-xs text-muted-foreground font-medium hover:underline"
             >
-              Forget your password?
+              Forgot password?
             </Link>
           </div>
           <Button

--- a/src/components/auth/signup.tsx
+++ b/src/components/auth/signup.tsx
@@ -98,7 +98,7 @@ const Signup = () => {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" {...field} placeholder="••••••••" />
+                  <Input type="password" {...field} placeholder="Password" />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -109,7 +109,7 @@ const Signup = () => {
               href={APP_PATHS.RESET_PASSWORD}
               className="text-xs text-muted-foreground font-medium hover:underline"
             >
-              Forget your password?
+              Forgot password?
             </Link>
           </div>
           <Button


### PR DESCRIPTION
There was a typo in signin and signup page. That is it was written forget your password which I corrected to forgot password.
Moreover I also changed the placeholder of password from ...... to Password for better readability.