### PR TITLE
fix:fixed filter

### DIFF
--- a/src/components/ui/paginator.tsx
+++ b/src/components/ui/paginator.tsx
@@ -18,6 +18,11 @@ export const PaginationPages = ({
   baseUrl: string;
 }) => {
   const setQueryParams = useSetQueryParams();
+
+  if (currentPage > totalPages) {
+    setQueryParams({ page: '1' });
+  }
+
   function paginationHandler(page: number) {
     setQueryParams({ page: page.toString() });
   }

--- a/src/layouts/job-filters.tsx
+++ b/src/layouts/job-filters.tsx
@@ -29,12 +29,14 @@ import useSetQueryParams from '@/hooks/useSetQueryParams';
 import { useEffect } from 'react';
 import { WorkMode } from '@prisma/client';
 import _ from 'lodash';
+import { DEFAULT_PAGE } from '@/config/app.config';
 
 const JobFilters = ({ searchParams }: { searchParams: JobQuerySchemaType }) => {
   const setQueryParams = useSetQueryParams();
   const form = useForm<JobQuerySchemaType>({
     resolver: zodResolver(JobQuerySchema),
     defaultValues: {
+      page: DEFAULT_PAGE,
       workmode: searchParams.workmode,
       salaryrange: searchParams.salaryrange,
       location: searchParams.location,


### PR DESCRIPTION

https://github.com/user-attachments/assets/dafb8bec-6660-4c16-b1a5-1415534e34f1

- #301 
@VineeTagarwaL-code I believe the issue is that when you navigate to a page other than 1 (e.g., page 2) and apply a filter, the page number remains unchanged. We need to ensure that the page number resets to 1 whenever a new filter is applied.