### PR TITLE
Fix: Conditionally rendered the p tag to show "per annum" text only when minSalary && maxSalary is valid

### DIFF
--- a/src/components/job-landing.tsx
+++ b/src/components/job-landing.tsx
@@ -103,9 +103,11 @@ const JobCard = async ({ searchParams }: PaginatorProps) => {
                     ? `$${formatSalary(job.maxSalary)}`
                     : 'Not Disclosed'}
                 </span>
-                <p className=" md:text-right text-xs text-muted-foreground mt-1">
-                  per annum
-                </p>
+                {job.minSalary && job.maxSalary && (
+                  <p className="md:text-right text-xs text-muted-foreground mt-1">
+                    per annum
+                  </p>
+                )}
               </div>
             </div>
           </Link>


### PR DESCRIPTION
WHAT DOES THIS PR DO?
This PR solves the issue of unnecessary text "per annum" even when the salary is not disclosed. Added conditional check to show and hide "per annum" text only when the minSalary and maxSalary are valid and available.

Fixes #376 