### PR TITLE
Fix: Typo in the spelling of disclaimer in the footer section.

### DIFF
--- a/src/components/job-landing.tsx
+++ b/src/components/job-landing.tsx
@@ -103,9 +103,11 @@ const JobCard = async ({ searchParams }: PaginatorProps) => {
                     ? `$${formatSalary(job.maxSalary)}`
                     : 'Not Disclosed'}
                 </span>
-                <p className=" md:text-right text-xs text-muted-foreground mt-1">
-                  per annum
-                </p>
+                {job.minSalary && job.maxSalary && (
+                  <p className="md:text-right text-xs text-muted-foreground mt-1">
+                    per annum
+                  </p>
+                )}
               </div>
             </div>
           </Link>

--- a/src/lib/constant/app.constant.ts
+++ b/src/lib/constant/app.constant.ts
@@ -15,7 +15,6 @@ export const navbar = [
   { id: 4, label: 'Testimonials', path: APP_PATHS.TESTIMONIALS },
   { id: 5, label: 'FAQs', path: APP_PATHS.FAQS },
   { id: 6, label: 'Post a Job', path: APP_PATHS.POST_JOB },
-
 ];
 
 export const socials: {
@@ -56,6 +55,6 @@ export const footerLinks = {
   '100xlegal': [
     { label: 'Privacy Policy', href: '' },
     { label: 'Terms of Service', href: '' },
-    { label: 'Desclaimer', href: '' },
+    { label: 'Disclaimer', href: '' },
   ],
 };


### PR DESCRIPTION
WHAT DOES THIS PR DO?
This PR solves the issue of "Disclaimer" typed as "Desclaimer" in the footer section. Corrected the word in the constants file in the codebase.

Fixes #379  