### PR TITLE
fixed app_paths for the testimonals and FAQs

### DIFF
--- a/src/config/path.config.ts
+++ b/src/config/path.config.ts
@@ -6,7 +6,7 @@ const APP_PATHS = {
   RESET_PASSWORD: '/reset-password',
   JOBS: '/jobs',
   MANAGE_JOBS: '/jobs/manage',
-  TESTIMONIALS: '#testimonials',
-  FAQS: '#faq',
+  TESTIMONIALS: '/#testimonials',
+  FAQS: '/#faq',
 };
 export default APP_PATHS;


### PR DESCRIPTION
When I was on the job stagging portal I noticed that testimonials and FAQs weren't working fine when the current page was not the root/home so I fixed the issue in the path.config.ts file