### PR TITLE
docs: Update Readme to include steps google maps api key and sample .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Follow these steps to set up the repository locally and run it.
 1. Create a `.env` file in the root folder of your project. Update it following the convention of the `.env.example` file. Here's an example:
 
    ```bash
-   DATABASE_URL="postgresql://postgres:123456@localhost:5432/job100x"
+   #
+   # Database 
+   #
+   DATABASE_URL="postgres://postgres:password@localhost:5432/postgres"
 
    #
    # AUTH 

--- a/README.md
+++ b/README.md
@@ -36,23 +36,22 @@ Follow these steps to set up the repository locally and run it.
 1. Create a `.env` file in the root folder of your project. Update it following the convention of the `.env.example` file. Here's an example:
 
    ```bash
-   #
-   # Database 
-   #
-   DATABASE_URL="postgres://postgres:password@localhost:5432/postgres"
+   DATABASE_URL="postgresql://postgres:123456@localhost:5432/job100x"
 
    #
    # AUTH 
    #
-   NEXTAUTH_SECRET="koXrQGB5TFD4KALDX4kAvnQ5RHHvAOIzB"
+   NEXTAUTH_SECRET=
    NEXTAUTH_URL="http://localhost:3000"
-
+   
    #
    # Bunny CDN
    #
-   CDN_SZ_NAME=
-   CDN_BASE_PATH=
    CDN_API_KEY=
+   CDN_BASE_UPLOAD_URL=
+   CDN_BASE_ACCESS_URL=
+   
+   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
    ```
 
 2. To generate AUTH_SECRET,
@@ -143,3 +142,41 @@ Password: '123456';
    Which is https://[your-pull-zone-hostname]/[any folder name you might have added otherwise empty] or get link from the dashboard as mentioned below 
    
    <img src="https://utfs.io/f/CUistsOk9f0IyM9047Pa7YvK8qbtnUAPO9jwxdskhzc2JNoR" alt=" CDN_BASE_ACCESS_URL"  width="600"  />
+
+
+# Steps to Set Up Google Maps Platform API Key
+
+To use the Google Maps API in your applications, follow the steps below to create and set up your API key.
+
+### Step 1: Go to Google Cloud Console
+1. Navigate to the [Google Cloud Console](https://console.cloud.google.com/).
+2. If you don’t have a Google account, create one and sign in.
+
+### Step 2: Create a New Project
+1. In the Cloud Console, click on the **Select a project** dropdown at the top.
+2. Click **New Project** to create a new project.
+3. Give your project a name, select the organization (optional), and choose the billing account.
+4. Click **Create**.
+
+### Step 3: Google Maps Platform 
+1. Search Google Maps Platform in the Console search bar
+<img width="1438" alt="Screenshot 2024-09-22 at 10 15 15 AM" src="https://github.com/user-attachments/assets/a5f93c1e-d7b6-4a5b-847b-868b1133643d">
+
+2. If your account is not setup yet , finish your account setup
+<img width="930" alt="Screenshot 2024-09-22 at 10 02 59 AM" src="https://github.com/user-attachments/assets/c8ee7aa3-7610-4836-86f6-c28e8604c2b9">
+
+3.After Completeing account setup ,  select the "Keys and Credentails" Section.
+4.Then select the Create Credentials option , under which you can select the "API Key Option"
+<img width="1440" alt="Screenshot 2024-09-22 at 10 05 36 AM" src="https://github.com/user-attachments/assets/9e897c91-3282-4e28-8fdf-d920d6c4bc15">
+
+5. You will receive a API Key , add the key to the NEXT_PUBLIC_GOOGLE_MAPS_API_KEY in the .env
+<img width="660" alt="Screenshot 2024-09-22 at 10 19 33 AM" src="https://github.com/user-attachments/assets/adcb5a49-892e-43a1-b318-56b296280611">
+
+
+
+### Step 4: Changes required to make it work on localhost
+1. Although the documentation mentions that without restriction , the API key will work everywhere, that is not the case for http requests.
+2. Add a restriction and mention your localhost along with your port  for it to start working on local ,  and save and continue
+<img width="694" alt="Screenshot 2024-09-22 at 10 06 44 AM" src="https://github.com/user-attachments/assets/3acfdf47-4b1d-480f-8172-0fbfa1c39f02">
+
+3. to test navigate to the http://localhost:3000/create , and test the "Where is the job located" input.


### PR DESCRIPTION
What does this PR do ?   Issue : [#383](https://github.com/code100x/job-board/issues/383)
1. Add Steps for setting up google maps api key in readme for helping contributors setup the project. 
[screenshot for steps added](https://github.com/user-attachments/assets/580be2cc-2c42-4691-851b-490165c382ed)

2. Update the Sample .env in the readme 

Before : 
<img width="873" alt="Screenshot 2024-09-22 at 10 42 12 AM" src="https://github.com/user-attachments/assets/abc14259-1789-4fd2-be19-182be5603fe7">

After : 
<img width="883" alt="Screenshot 2024-09-22 at 10 42 18 AM" src="https://github.com/user-attachments/assets/fc4dea3f-d573-476e-9c68-45a4a425f07e">
