### PR TITLE
UI Improvements of Skills Tag and fixes Design according to the issue #368

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.426.0",
     "next": "^14.2.12",
-    "next-auth": "^4.24.7",
+    "next-auth": "^4.24.8",
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^3.7.15",
     "node-cron": "^3.0.3",

--- a/src/components/Jobcard.tsx
+++ b/src/components/Jobcard.tsx
@@ -41,12 +41,14 @@ export default function JobCard({
           </h2>
           <div className="flex">
             <p>{job.companyName + '.'} </p>
-            <p className="ml-2">{'Posted on ' + job.postedAt.toDateString()}</p>
+            <p className="ml-2">
+              {'• Posted on ' + job.postedAt.toDateString()}
+            </p>
           </div>
         </div>
       </div>
       <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-        <div className="p-2 bg-blue-100 dark:bg-blue-500 dark:bg-opacity-10 bg-opacity-90 text-blue-500 dark:text-blue-400 rounded">
+        <div className="p-2 bg-blue-100 dark:bg-blue-500 dark:bg-opacity-10 bg-opacity-90 text-blue-500 dark:text-blue-400 rounded-sm">
           {_.startCase(job.type)}
         </div>
         <span className="flex items-center gap-0.5">

--- a/src/components/job-skills.tsx
+++ b/src/components/job-skills.tsx
@@ -15,7 +15,7 @@ export const JobSkills = ({ skills }: JobSkillsProps) => {
         <SkillTag key={index} skill={skill} />
       ))}
       {remainingSkillsCount > 0 && (
-        <div className="bg-slate-500 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full px-2">
+        <div className="bg-slate-500 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full p-2">
           +{remainingSkillsCount} more
         </div>
       )}
@@ -23,12 +23,12 @@ export const JobSkills = ({ skills }: JobSkillsProps) => {
   );
 };
 const NoSkills = () => (
-  <div className="mt-3 bg-slate-500 flex justify-start items-center gap-3 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full px-2">
+  <div className="mt-3 bg-slate-500 flex justify-start items-center gap-3 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full">
     <icons.alert size={12} /> No skills provided
   </div>
 );
 const SkillTag = ({ skill }: { skill: string }) => (
-  <div className="bg-slate-500 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full px-2">
+  <div className="bg-slate-500 bg-opacity-10 text-slate-500 dark:text-slate-400 font-medium text-sm rounded-full p-2">
     {skill}
   </div>
 );


### PR DESCRIPTION
Added ui improvement according to figma design (#368):

Before: 
![image](https://github.com/user-attachments/assets/bc4c37fe-489a-4f1f-b6ba-93122ce71add)

After: 
![image](https://github.com/user-attachments/assets/9b6c0b65-03c3-47b8-a301-eb0c3b73e294)

- Added the dot before Job Posted 
- Improved padding on Job Card components like: skills tag according to figma design 
![image](https://github.com/user-attachments/assets/e8de1a48-6f78-468a-b75c-a7332466d529)

