### PR TITLE
Issue #523 Non disclosed salary filtering issue resolved

### DIFF
--- a/src/actions/job.action.ts
+++ b/src/actions/job.action.ts
@@ -112,7 +112,7 @@ export const getAllJobs = withServerActionAsyncCatcher<
   const { filterQueries, orderBy, pagination } = getJobFilters(result);
   const queryJobsPromise = prisma.job.findMany({
     ...pagination,
-    orderBy: [orderBy],
+    orderBy: orderBy,
     where: {
       isVerifiedJob: true,
       expired: false,

--- a/src/services/jobs.services.ts
+++ b/src/services/jobs.services.ts
@@ -66,7 +66,7 @@ export function getJobFilters({
   };
   const [sort, sortOrder] = sortby.split('_');
   const orderBy: Prisma.JobOrderByWithAggregationInput = sortby
-    ? { [sortFieldMapping[sort]]: sortOrder }
+    ? { [sortFieldMapping[sort]]: { sort: sortOrder, nulls: 'last' } }
     : {};
 
   const pagination = {


### PR DESCRIPTION
Solution: If salary value is not defined / null, then order it by last.

```
orderBy: [
    {
      maxSalary: {
        sort: 'desc',
        nulls: 'last',  // Place jobs with null maxSalary at the end
      },
    },
  ],
```

![image](https://github.com/user-attachments/assets/fe12df34-b9ef-413f-b13d-c51393ffb409)
![image](https://github.com/user-attachments/assets/7dd395e7-0e76-4ef0-a866-8473bebcf961)
