### PR TITLE
feat: improve mobile view for dialog UI

### DIFF
--- a/src/app/profile/experience/page.tsx
+++ b/src/app/profile/experience/page.tsx
@@ -11,7 +11,7 @@ import { AddExperience } from '@/components/user-multistep-form/addExperience-fo
 import APP_PATHS from '@/config/path.config';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 export default function AccountExperiencePage() {
   const router = useRouter();
@@ -26,9 +26,9 @@ export default function AccountExperiencePage() {
         <span>Experience</span>
         <Dialog>
           <DialogTrigger>Add more</DialogTrigger>
-          <DialogContent className="max-w-md max-h-[90vh] flex flex-col p-0">
+          <DialogContent className="w-4/5 sm:w-[400px] max-h-[90vh] flex flex-col p-0 rounded-xl">
             <DialogHeader className="p-6 pb-2">
-              <DialogTitle>Add Experience</DialogTitle>
+              <DialogTitle className="">Add Experience</DialogTitle>
             </DialogHeader>
             <div className="flex-grow overflow-y-auto px-6 pb-6">
               <AddExperience />

--- a/src/app/profile/projects/page.tsx
+++ b/src/app/profile/projects/page.tsx
@@ -26,7 +26,7 @@ export default function AccountProjectPage() {
         <span>Projects</span>
         <Dialog>
           <DialogTrigger>Add more</DialogTrigger>
-          <DialogContent className="max-w-md max-h-[90vh] flex flex-col p-0">
+          <DialogContent className="w-4/5 sm:w-[400px] max-h-[90vh] flex flex-col p-0 rounded-xl">
             <DialogHeader className="p-6 pb-2">
               <DialogTitle>Add Project</DialogTitle>
             </DialogHeader>

--- a/src/app/profile/skills/page.tsx
+++ b/src/app/profile/skills/page.tsx
@@ -26,7 +26,7 @@ export default function AccountResumePage() {
         <span>Skills</span>
         <Dialog>
           <DialogTrigger>Add more</DialogTrigger>
-          <DialogContent className="max-w-md max-h-[90vh] flex flex-col p-0">
+          <DialogContent className="w-4/5 sm:w-[400px] max-h-[90vh] flex flex-col p-0 rounded-xl">
             <DialogHeader className="p-6 pb-2">
               <DialogTitle>Add Skills</DialogTitle>
             </DialogHeader>

--- a/src/components/ShareJobDialog.tsx
+++ b/src/components/ShareJobDialog.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -7,8 +6,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Twitter, Linkedin, Share2 } from 'lucide-react';
 import { JobType } from '@/types/jobs.types';
+import { Linkedin, Share2, Twitter } from 'lucide-react';
+import React from 'react';
 
 interface ShareOption {
   name: string;
@@ -70,7 +70,7 @@ export const ShareJobDialog = ({ job }: { job: JobType }) => {
           Share Job <Share2 size={16} />
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="  w-4/5 sm:w-[400px]  rounded-2xl ">
         <DialogHeader>
           <DialogTitle>Share Job</DialogTitle>
         </DialogHeader>

--- a/src/components/profile/UserExperience.tsx
+++ b/src/components/profile/UserExperience.tsx
@@ -1,9 +1,9 @@
 import { getUserExperience } from '@/actions/user.profile.actions';
-import { useEffect, useState } from 'react';
-import { useToast } from '../ui/use-toast';
+import icons from '@/lib/icons';
 import { Experience } from '@prisma/client';
 import _ from 'lodash';
-import icons from '@/lib/icons';
+import { useEffect, useState } from 'react';
+import { useToast } from '../ui/use-toast';
 export function UserExperience() {
   const { toast } = useToast();
   const [experiences, setExperiences] = useState<Experience[] | undefined>();
@@ -41,7 +41,7 @@ export function UserExperience() {
   }
 
   return (
-    <div className="space-y-2 mb-2">
+    <div className="space-y-2 mb-2 ">
       {experiences.map((item: Experience) => (
         <div
           key={item.id}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import * as React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
 import {
   Controller,
   ControllerProps,
@@ -12,8 +12,8 @@ import {
   useFormContext,
 } from 'react-hook-form';
 
-import { cn } from '@/lib/utils';
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 
 const Form = FormProvider;
 
@@ -80,7 +80,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+      <div ref={ref} className={cn('space-y-2 ', className)} {...props} />
     </FormItemContext.Provider>
   );
 });
@@ -168,12 +168,12 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = 'FormMessage';
 
 export {
-  useFormField,
   Form,
-  FormItem,
-  FormLabel,
   FormControl,
   FormDescription,
-  FormMessage,
   FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
 };

--- a/src/components/user-multistep-form/addExperience-form.tsx
+++ b/src/components/user-multistep-form/addExperience-form.tsx
@@ -79,7 +79,7 @@ export const AddExperience = () => {
   const WatchCurrentWorkStatus = form.watch('currentWorkStatus');
 
   return (
-    <div className="p-2 max-w-md ">
+    <div className="p-2 max-w-md  ">
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField


### PR DESCRIPTION
While Creating a Profile in mobile view the add dialogs are just coinciding with the screen, and the share job dialog too
currently,shadcn dialog uses 100vw width so we can reduce 5% in mobile view to fix this,